### PR TITLE
Change names of methods for Parser Class

### DIFF
--- a/src/main/java/SnomStorage/TaskStorage.java
+++ b/src/main/java/SnomStorage/TaskStorage.java
@@ -1,11 +1,11 @@
 package SnomStorage;
 
-import snomexceptions.InvalidCommandIndexException;
-import snomtasklist.TaskList;
-
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+
+import snomexceptions.InvalidCommandIndexException;
+import snomtasklist.TaskList;
 
 public class TaskStorage {
 
@@ -34,8 +34,8 @@ public class TaskStorage {
 
     private void updateFile(String filename, TaskList lst) {
         try {
-            for (int i = 1; i <= lst.getCounter(); i++) {
-                writeToFile(filename, lst.getTask(i) + System.lineSeparator());
+            for (int i = 1; i <= lst.getTaskNum(); i++) {
+                writeToFile(filename, lst.getTaskAtIndex(i) + System.lineSeparator());
                 //System.out.println(lst.getTask(i));
             }
         } catch (IOException e) {

--- a/src/main/java/inputcommands/ByeCommand.java
+++ b/src/main/java/inputcommands/ByeCommand.java
@@ -9,9 +9,6 @@ import snomtasklist.TaskList;
  */
 public class ByeCommand extends Command {
 
-    private ByeCommand(String desc) {
-        super(desc);
-    }
 
     protected ByeCommand() {
         super(" ");
@@ -34,7 +31,7 @@ public class ByeCommand extends Command {
      * This method returns the string to terminate the execution of SnomBot.
      * @param t is the instance of Storage.TaskList.TaskList containing all the tasks.
      * @return a string representing the command to terminate the execution of SnomBot.
-     * @throws InvalidCommandException
+     * @throws InvalidCommandException if the command executed is invalid.
      */
     @Override
     public String execute(TaskList t) throws InvalidCommandException {

--- a/src/main/java/inputcommands/Command.java
+++ b/src/main/java/inputcommands/Command.java
@@ -40,10 +40,7 @@ public abstract class Command {
      */
     public static Command makeCommand(String description) throws InvalidCommandException {
         String type = description.split(" ")[0].toLowerCase();
-        String[] commandlst = {"list", "bye", "mark", "unmark", "delete", "todo", "deadline", "event"};
-
-        Command cmd = null;
-
+        Command cmd;
         switch (type) {
         case "list":
             cmd = new ListCommand();

--- a/src/main/java/inputcommands/DeleteTaskCommand.java
+++ b/src/main/java/inputcommands/DeleteTaskCommand.java
@@ -42,7 +42,7 @@ class DeleteTaskCommand extends Command {
     public String execute(TaskList lst) throws InvalidCommandIndexException {
         try {
             int pos = Integer.parseInt(this.desc.split(" ")[1]);
-            lst.getTask(pos);
+            lst.getTaskAtIndex(pos);
             return "delete " + pos;
         } catch (InvalidCommandIndexException e) {
             throw new InvalidCommandIndexException();

--- a/src/main/java/inputcommands/MarkTaskCommand.java
+++ b/src/main/java/inputcommands/MarkTaskCommand.java
@@ -43,7 +43,7 @@ class MarkTaskCommand extends Command {
     public String execute(TaskList lst) throws InvalidCommandIndexException {
         try {
             int pos = Integer.parseInt(this.desc.split(" ")[1]);
-            lst.getTask(pos);
+            lst.getTaskAtIndex(pos);
             return Integer.toString(pos);
         } catch (InvalidCommandIndexException e) {
             throw new InvalidCommandIndexException();

--- a/src/main/java/inputcommands/UnmarkTaskCommand.java
+++ b/src/main/java/inputcommands/UnmarkTaskCommand.java
@@ -45,7 +45,7 @@ class UnmarkTaskCommand extends Command {
     public String execute(TaskList lst) throws InvalidCommandIndexException {
         try {
             int pos = Integer.parseInt(this.desc.split(" ")[1]);
-            lst.getTask(pos);
+            lst.getTaskAtIndex(pos);
             return Integer.toString(pos);
         } catch (InvalidCommandIndexException e) {
             throw new InvalidCommandIndexException();

--- a/src/main/java/snomparser/Parser.java
+++ b/src/main/java/snomparser/Parser.java
@@ -15,6 +15,9 @@ import snomtasklist.TaskList;
  */
 public class Parser {
 
+    private static final int DEADLINE_TASK_LENGTH = 2;
+    private static final int EVENT_TASK_LENGTH = 3;
+
 
     /**
      * Processes the command, and returns a String output
@@ -30,46 +33,46 @@ public class Parser {
 
     public String processCommand(Command command, TaskList lst, TaskStorage storage) {
 
-        boolean status = true;
+
         try {
             String cmd = command.execute(lst);
             assert cmd != null : "Command cannot be null";
-            String result = "";
+            String result;
             switch (command.getType()) {
             case DEADLINE:
-                result = this.addDeadline(lst, storage, cmd);
+                result = this.addDeadlineToTaskList(lst, cmd);
                 break;
             case EVENT:
-                result = this.addEvent(lst, storage, cmd);
+                result = this.addEventToTaskList(lst, cmd);
                 break;
             case TODO:
-                result = this.addTodo(lst, storage, cmd);
+                result = this.addTodoToTaskList(lst, cmd);
                 break;
             case MARK:
-                result = this.doTask(lst, storage, Integer.parseInt(cmd));
+                result = this.doTaskInTaskList(lst, Integer.parseInt(cmd));
                 break;
             case UNMARK:
-                result = this.undoTask(lst, storage, Integer.parseInt(cmd));
+                result = this.undoTaskInTaskList(lst, Integer.parseInt(cmd));
                 break;
             case DELETE:
-                result = this.deleteTask(lst, storage, Integer.parseInt(cmd));
+                result = this.deleteTaskFromTaskList(lst, Integer.parseInt(cmd));
                 break;
             case LIST:
-                result = this.listTask(lst, storage);
+                result = this.listTaskInTaskList(lst);
                 break;
             case FIND:
-                result = this.findTask(lst, cmd);
+                result = this.findTaskInTaskList(lst, cmd);
                 break;
             case BYE:
                 result = "bye";
                 break;
             default:
-                result = "None";
+                result = "Invalid Task";
 
 
 
             }
-            assert result.equals("None") : "Invalid task added";
+            assert result.equals("Invalid Task") : "Invalid task added";
 
             storage.saveTask(lst);
             return result;
@@ -82,59 +85,57 @@ public class Parser {
     }
 
 
-    private String addTodo(TaskList lst, TaskStorage storage, String cmd) {
+    private String addTodoToTaskList(TaskList lst, String cmd) {
         return lst.addTask(new Todo(cmd));
 
     }
 
-    private String addDeadline(TaskList lst, TaskStorage storage, String cmd) {
-        String name = cmd.split("/", 2)[0];
+    private String addDeadlineToTaskList(TaskList lst, String cmd) {
+        String name = cmd.split("/", DEADLINE_TASK_LENGTH)[0];
 
-        String due_date = cmd.split("/", 2)[1];
+        String due_date = cmd.split("/", DEADLINE_TASK_LENGTH)[1];
         return lst.addTask(new Deadline(name, due_date));
 
     }
 
-    private String addEvent(TaskList lst, TaskStorage storage, String cmd) {
-        String name = cmd.split("/", 3)[0];
-        String start = cmd.split("/", 3)[1];
-        String end = cmd.split("/", 3)[2];
+    private String addEventToTaskList(TaskList lst, String cmd) {
+        String name = cmd.split("/", EVENT_TASK_LENGTH)[0];
+        String start = cmd.split("/", EVENT_TASK_LENGTH)[1];
+        String end = cmd.split("/", EVENT_TASK_LENGTH)[2];
 
         return lst.addTask(new Event(name, start, end));
     }
 
-    private String doTask(TaskList lst, TaskStorage storage, int pos) {
+    private String doTaskInTaskList(TaskList lst, int pos) {
         try {
-            return lst.markTask(pos);
+            return lst.markTaskAtIndex(pos);
         } catch (InvalidCommandException e) {
             System.out.println(e.getMessage());
             return "this should not happen1";
         }
     }
 
-    private String undoTask(TaskList lst, TaskStorage storage, int pos) {
+    private String undoTaskInTaskList(TaskList lst, int pos) {
         try {
-            return lst.unmarkTask(pos);
+            return lst.unmarkTaskAtIndex(pos);
         } catch (InvalidCommandException e) {
-            System.out.println(e.getMessage());
-            return "this should not happen2";
+            return "Invalid Task";
         }
     }
 
-    private String deleteTask(TaskList lst, TaskStorage storage, int pos) {
+    private String deleteTaskFromTaskList(TaskList lst, int pos) {
         try {
-            return lst.deleteTask(pos);
+            return lst.deleteTaskAtIndex(pos);
         } catch (InvalidCommandException e) {
-
-            return "this should not happen3";
+            return "Invalid Task";
         }
     }
 
-    private String listTask(TaskList lst, TaskStorage storage) {
+    private String listTaskInTaskList(TaskList lst) {
         return lst.displayTaskList();
     }
 
-    private String findTask(TaskList lst, String cmd) {
+    private String findTaskInTaskList(TaskList lst, String cmd) {
         return lst.printMatchingTasks(cmd);
     }
 

--- a/src/main/java/snomtasklist/TaskList.java
+++ b/src/main/java/snomtasklist/TaskList.java
@@ -16,8 +16,8 @@ public class TaskList {
     }
 
     /**
-     * Makes a empty tasklist.
-     * @return a empty tasklist.
+     * Makes an empty taskList.
+     * @return an empty taskList.
      */
     public static TaskList makeTaskList() {
         return new TaskList();
@@ -31,7 +31,7 @@ public class TaskList {
      * @throws InvalidCommandIndexException if the index is out
      *         of range of the tasklist.
      */
-    public Task getTask(int pos) throws InvalidCommandIndexException {
+    public Task getTaskAtIndex(int pos) throws InvalidCommandIndexException {
 
         if (counter < pos || pos <= 0) {
             throw new InvalidCommandIndexException();
@@ -50,7 +50,7 @@ public class TaskList {
      *         of range of the tasklist.
      * @return a String representing whether the task is successfully added.
      */
-    public String markTask(int pos) throws InvalidCommandIndexException {
+    public String markTaskAtIndex(int pos) throws InvalidCommandIndexException {
 
 
         if (counter < pos || pos <= 0) {
@@ -75,7 +75,7 @@ public class TaskList {
      * @return a string representing if the task is successfully unmarked.
      */
 
-    public String unmarkTask(int pos) throws InvalidCommandIndexException {
+    public String unmarkTaskAtIndex(int pos) throws InvalidCommandIndexException {
 
 
         if (counter < pos || pos <= 0) {
@@ -98,7 +98,7 @@ public class TaskList {
      *         of range of the tasklist.
      * @return a string representing if the task is successfully deleted.
      */
-    public String deleteTask(int pos) throws InvalidCommandIndexException {
+    public String deleteTaskAtIndex(int pos) throws InvalidCommandIndexException {
 
 
         if (counter < pos || pos <= 0) {
@@ -132,7 +132,7 @@ public class TaskList {
      * @return an integer representing the number
      *         of the tasks within the tasklist.
      */
-    public int getCounter() {
+    public int getTaskNum() {
         return this.counter;
     }
 
@@ -159,16 +159,16 @@ public class TaskList {
      *            the user wishes to search for in the tasklist.
      */
     public String printMatchingTasks(String cmd) {
-        ArrayList<Task> found_tasks = new ArrayList<>();
+        ArrayList<Task> foundTasks = new ArrayList<>();
         for (int i = 0; i<counter; i++) {
             if (this.taskList.get(i).match(cmd)) {
-                found_tasks.add(taskList.get(i));
+                foundTasks.add(taskList.get(i));
             }
         }
         StringBuilder lst = new StringBuilder();
-        if (found_tasks.size() > 0) {
+        if (!foundTasks.isEmpty()) {
             System.out.println("Here are the tasks that match your description");
-            for (int j = 0; j < found_tasks.size(); j++) {
+            for (int j = 0; j < foundTasks.size(); j++) {
                 lst.append(this.taskList.get(j) + "\n");
             }
             return lst.toString();


### PR DESCRIPTION
There are identical names for methods for the Parser class and the TaskList class.

Changing the names for the Parser class and TaskList class can improve code quality, as the method names now provide a clearer idea of what the method does to the respective classes.

Let's changes the names of addTask methods of Parser to addTaskToTaskList and addTask respectively.

The reader will be able to
understand that Parser is modifying the instance of TaskList, while the TaskList is getting modified through the usage of the AddTask method.